### PR TITLE
Change the GNOME Shell app title to Ignition

### DIFF
--- a/ignition/Main.py
+++ b/ignition/Main.py
@@ -14,6 +14,8 @@ from Install import *
 class HomeWindow(Gtk.ApplicationWindow):
     def __init__(self):
         Gtk.Window.__init__(self, title="Ignition")
+        self.set_wmclass("Ignition", "Ignition")
+
         # system("mkdir ~/.local/share/ignition/")
         # self.appdata = home+"/.local/share/ignition/"
 


### PR DESCRIPTION
In GNOME Shell, this commit changes the name in the top bar (and perhaps some other places too) from `Main.py` to `Ignition`. I am not sure of its effect (or if it has any effect) on other DEs.